### PR TITLE
Updated mount.pp with correct require

### DIFF
--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -20,6 +20,7 @@ define glusterfs::mount (
     device  => $device,
     fstype  => 'glusterfs',
     options => $options,
+    require => Package['glusterfs-fuse'],
   }
 
 }


### PR DESCRIPTION
Mounting a GlusterFS filesystem requires glusterfs-fuse to be installed before mounting.
