### PR TITLE
mount resource cannot be remounted, allow distinguishing title and path in glusterfs::mount

### DIFF
--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -9,13 +9,14 @@
 #
 define glusterfs::mount (
   $device,
+  $path    = $name,
   $options = 'defaults',
   $ensure  = 'mounted'
 ) {
 
   include glusterfs::client
 
-  mount { $title:
+  mount { $path:
     ensure   => $ensure,
     device   => $device,
     fstype   => 'glusterfs',
@@ -25,4 +26,3 @@ define glusterfs::mount (
   }
 
 }
-

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -16,11 +16,12 @@ define glusterfs::mount (
   include glusterfs::client
 
   mount { $title:
-    ensure  => $ensure,
-    device  => $device,
-    fstype  => 'glusterfs',
-    options => $options,
-    require => Package['glusterfs-fuse'],
+    ensure   => $ensure,
+    device   => $device,
+    fstype   => 'glusterfs',
+    options  => $options,
+    remounts => false,
+    require  => Package['glusterfs-fuse'],
   }
 
 }


### PR DESCRIPTION
The Gluster Fuse module unfortunately does not support the '-o remount' flag (yet ?)

Setting it to false gives puppet peace. When changing mount options it seems to refresh the resource. Not sure if the refresh actually does anything, but at least the fstab entry get updated correctly.

The other commit allows you to specify the path of the mountpoint while keeping a uniqe resource title. This is important to have puppet make the correct modifications in /etc/fstab when you change some options to the same resource instead of adding one below potentially causing issues after a reboot due to double entries.

Signed-off-by: Christophe Vanlancker christophe.vanlancker@inuits.eu
