### PR TITLE
Add _netdev to default mount options and allow to modify the fstype

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ on the same hardware for optimal performance and optimal fail-over :
 
     file { '/var/www': ensure => directory }
     glusterfs::mount { '/var/www':
+      fstype => 'glusterfs',
       device => $::hostname ? {
         'client1' => '192.168.0.1:/gv0',
         'client2' => '192.168.0.2:/gv0',

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -10,18 +10,31 @@
 define glusterfs::mount (
   $device,
   $options = 'defaults,_netdev',
+  $fstype  = 'glusterfs',
   $ensure  = 'mounted'
 ) {
 
   include glusterfs::client
 
-  mount { $title:
-    ensure  => $ensure,
-    device  => $device,
-    fstype  => 'glusterfs',
-    options => $options,
-    require => Package['glusterfs-fuse'],
+  if $fstype == 'glusterfs' {
+    mount { $title:
+      ensure  => $ensure,
+      device  => $device,
+      fstype  => $fstype,
+      options => $options,
+      require => Package['glusterfs-fuse'],
+    }
   }
-
+  elseif $fstype == 'nfs' {
+    mount { $title:
+      ensure  => $ensure,
+      device  => $device,
+      fstype  => $fstype,
+      options => $options,
+    }
+  }
+  else {
+    fail("$fstype is not a valid filesystem for gluster")
+  }
 }
 

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -25,7 +25,7 @@ define glusterfs::mount (
       require => Package['glusterfs-fuse'],
     }
   }
-  elseif $fstype == 'nfs' {
+  elsif $fstype == 'nfs' {
     mount { $title:
       ensure  => $ensure,
       device  => $device,

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -9,7 +9,7 @@
 #
 define glusterfs::mount (
   $device,
-  $options = 'defaults',
+  $options = 'defaults,_netdev',
   $ensure  = 'mounted'
 ) {
 


### PR DESCRIPTION
Hi - 
- To avoid trouble with mounting the glusterfs volume I would like to have the '_netdev' option as default mount option. _netdev takes care of the network service availabilty before trying to mount a network share during boot.
  This is also the proposed solution by gluster.org: http://www.gluster.org/community/documentation/index.php/Gluster_3.2:_Automatically_Mounting_Volumes
- Due to performance issues on my webserver cluster with the fuse.glusterfs I had to switch to NFS. Right now the modules does not allow this. I updated and tested the module to allow to switch between nfs and glusterfs as fstypes. 

Regards,
Matthias
