### PR TITLE
Update 'unless' condition before triggering a glusterfs volume startup.

### DIFF
--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -18,7 +18,7 @@ define glusterfs::volume (
   }
 
   exec { "/usr/sbin/gluster volume start ${title}":
-    unless  => "[ \"`gluster volume info ${title} | egrep '^Status:'`\" = 'Status: Started' ]",
+    unless  => "gluster volume info ${title} | grep '^Status: Started' > /dev/null",
     path    => [ '/usr/sbin', '/usr/bin', '/sbin', '/bin' ],
     require => Exec["gluster volume create ${title}"],
   }


### PR DESCRIPTION
Not certain but IMHO, previous 'unless' statement was ineffective to prevent successive attempts of volume startup
leading to multiple log entries.
